### PR TITLE
Refile: Fix Ruby 3.2+ compatibility issues

### DIFF
--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -1,6 +1,7 @@
 require "json"
 require "sinatra/base"
 require "tempfile"
+require "tmpdir"
 
 module Refile
   # A Rack application which can be mounted or run on its own.

--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -145,7 +145,7 @@ module Refile
     end
 
     def remove?
-      remove and remove != "" and remove !~ /\A0|false$\z/
+      remove and remove != "" and remove.to_s !~ /\A0|false$\z/
     end
 
     def present?

--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -97,10 +97,6 @@ module Refile
               super(method, *args)
             end
           end
-
-          define_method(:respond_to_missing?) do |method, include_private = false|
-            super(method, include_private)
-          end
         end
 
         include mod

--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -97,6 +97,10 @@ module Refile
               super(method, *args)
             end
           end
+
+          define_method(:respond_to_missing?) do |method, include_private = false|
+            super(method, include_private)
+          end
         end
 
         include mod

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -12,7 +12,7 @@ module Refile
       # @see AttachmentHelper#attachment_cache_field
       def attachment_cache_field(method, options = {})
         self.multipart = true
-        @template.attachment_cache_field(@object_name, method, objectify_options(options))
+        @template.attachment_cache_field(@object_name, method, **objectify_options(options))
       end
     end
 
@@ -73,7 +73,6 @@ module Refile
     # @option options [Boolean] presign     If set to true, adds the appropriate data attributes for presigned uploads with refile.js.
     # @return [ActiveSupport::SafeBuffer]   The generated form field
     def attachment_field(object_name, method, object:, **options)
-      object = options[:object]
       options[:data] ||= {}
 
       definition = object.send(:"#{method}_attachment_definition")

--- a/lib/refile/version.rb
+++ b/lib/refile/version.rb
@@ -1,3 +1,3 @@
 module Refile
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end

--- a/refile.gemspec
+++ b/refile.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib spec app config Readme.md`.split($/).reject { |f| f.include?("test_app") }
   spec.require_paths = %w[lib spec] # spec is used by backend gems to run their tests
 
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "sinatra", ">= 2.0.0"
   spec.add_dependency "mime-types"


### PR DESCRIPTION
#### What does this PR do? (required)
Fixes three bugs and adds cleanup for Ruby 3.2+ compatibility:

- **Bug 1** (`attacher.rb`): `Object#=~` was removed in Ruby 3.2. When `remove` is set to a boolean `true`, calling `!~` raised `NoMethodError`. Fixed by calling `.to_s` first.
- **Bug 2** (`attachment_helper.rb`): Missing `**` splat when passing options hash to `attachment_cache_field` from the form builder. Broken since Ruby 3.0 keyword argument separation.
- **Bug 3** (`attachment_helper.rb`): The `object:` keyword arg in `attachment_field` was immediately overwritten with `options[:object]` (always `nil`), introduced during the Rails 7.1 refactor. Removed the offending line.
- Add explicit `require "tmpdir"` for `Dir::Tmpname` usage in `app.rb`
- Update `required_ruby_version` to `>= 3.1.0` in gemspec

#### Link to Basecamp to-do, Trello card, New Relic or Honeybadger (required)
https://linear.app/wealthbox-crm/issue/SRE-75/refile-fix-ruby-34-compatibility-issues-high-risk

#### What platforms should be included in QA?
- [x] Desktop web
- [ ] Mobile web
- [ ] iOS native app
- [ ] Android native app
- [ ] API
- [ ] N/A

#### QA steps
- [x] Install the gem on a Ruby 3.4 environment: `gem install refile` should succeed without errors
- [x] Verify `gem build refile.gemspec` completes cleanly on Ruby 3.4 / RubyGems 3.5+

#### Screenshots (if appropriate)
N/A